### PR TITLE
fix: token info url is optional

### DIFF
--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/CredentialsFile.scala
@@ -106,7 +106,7 @@ object CredentialsFile {
       audience: String,
       subject_token_type: String,
       token_url: String,
-      token_info_url: String,
+      token_info_url: Option[String],
       service_account_impersonation_url: Option[String],
       service_account_impersonation: Option[ServiceAccountImpersonationSettings],
       quota_project_id: Option[String],


### PR DESCRIPTION
See https://github.com/googleapis/google-auth-library-java/blob/5226e760683f67b395c14341fa8736c4161a3373/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java#L141