### PR TITLE
tweak: google credentials may not have project id

### DIFF
--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ExternalAccountCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ExternalAccountCredentials.scala
@@ -48,18 +48,9 @@ object ExternalAccountCredentials {
       client: Client[F],
       externalAccount: CredentialsFile.ExternalAccount,
       scopes: Seq[String],
-  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] = {
-    val pid: F[String] = externalAccount.quota_project_id match {
-      case Some(id) => F.pure(id)
-      case None =>
-        F.pure(
-          "quota project id for external account is nullable." +
-            "Perhaps, we need change GoogleCredentials#id signature.",
-        )
-    }
-
+  )(implicit F: Temporal[F]): F[GoogleCredentials[F]] =
     for {
-      id <- pid
+      id <- F.pure(externalAccount.quota_project_id)
       impersonationURL <- externalAccount.service_account_impersonation_url.traverse(
         Uri.fromString.andThen(F.fromEither),
       )
@@ -92,5 +83,4 @@ object ExternalAccountCredentials {
             F.raiseError(new NotImplementedError("AwsCredentials is not implemented yet."))
         }
     } yield credentials
-  }
 }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/GoogleCredentials.scala
@@ -17,6 +17,9 @@
 package org.http4s.googleapis.runtime.auth
 
 trait GoogleCredentials[F[_]] {
-  def projectId: String
+
+  /** obtain quota project id if any.
+    */
+  def projectId: Option[String]
   def get: F[AccessToken]
 }

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/IdentityPoolCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/IdentityPoolCredentials.scala
@@ -33,7 +33,7 @@ object IdentityPoolCredentials extends ExternalAccountSubjectTokenProvider {
     */
   private[auth] def fromFile[F[_]: Files](
       client: Client[F],
-      projectId: String,
+      projectId: Option[String],
       impersonationURL: Option[Uri],
       fileSource: ExternalCredentialSource.File,
       externalAccount: CredentialsFile.ExternalAccount,
@@ -49,7 +49,7 @@ object IdentityPoolCredentials extends ExternalAccountSubjectTokenProvider {
     */
   private[auth] def fromURL[F[_]](
       client: Client[F],
-      projectId: String,
+      projectId: Option[String],
       impersonationURL: Option[Uri],
       urlSource: ExternalCredentialSource.Url,
       externalAccount: CredentialsFile.ExternalAccount,
@@ -61,7 +61,7 @@ object IdentityPoolCredentials extends ExternalAccountSubjectTokenProvider {
 
   private def withoutImpersonation[F[_]: Files](
       client: Client[F],
-      pid: String,
+      pid: Option[String],
       fileSource: ExternalCredentialSource.File,
       externalAccount: CredentialsFile.ExternalAccount,
       scopes: Seq[String],
@@ -82,7 +82,7 @@ object IdentityPoolCredentials extends ExternalAccountSubjectTokenProvider {
   }
   private def withoutImpersonation[F[_]](
       client: Client[F],
-      pid: String,
+      pid: Option[String],
       urlSource: ExternalCredentialSource.Url,
       externalAccount: CredentialsFile.ExternalAccount,
       scopes: Seq[String],
@@ -116,7 +116,7 @@ object IdentityPoolCredentials extends ExternalAccountSubjectTokenProvider {
     */
   private def withoutImpersonation[F[_]](
       client: Client[F],
-      pid: String,
+      pid: Option[String],
       retrieveSubjectToken: F[String],
       externalAccount: CredentialsFile.ExternalAccount,
       scopes: Seq[String],
@@ -133,7 +133,7 @@ object IdentityPoolCredentials extends ExternalAccountSubjectTokenProvider {
 
   private def withImpersonation[F[_]: Files](
       client: Client[F],
-      id: String,
+      id: Option[String],
       impersonationURL: Uri,
       fileSource: ExternalCredentialSource.File,
       externalAccount: CredentialsFile.ExternalAccount,
@@ -156,7 +156,7 @@ object IdentityPoolCredentials extends ExternalAccountSubjectTokenProvider {
   }
   private def withImpersonation[F[_]](
       client: Client[F],
-      id: String,
+      id: Option[String],
       impersonationURL: Uri,
       urlSource: ExternalCredentialSource.Url,
       externalAccount: CredentialsFile.ExternalAccount,
@@ -191,7 +191,7 @@ object IdentityPoolCredentials extends ExternalAccountSubjectTokenProvider {
     */
   private def withImpersonation[F[_]](
       client: Client[F],
-      id: String,
+      id: Option[String],
       impersonationURL: Uri,
       retrieveSubjectToken: F[String],
       externalAccount: CredentialsFile.ExternalAccount,

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ImpersonatedCredentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/ImpersonatedCredentials.scala
@@ -48,7 +48,7 @@ object ImpersonatedCredentials {
     */
   def apply[F[_]](
       client: Client[F],
-      id: String,
+      id: Option[String],
       impersonationURL: Uri,
       retrieveSubjectToken: F[String],
       externalAccount: CredentialsFile.ExternalAccount,

--- a/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2Credentials.scala
+++ b/runtime/shared/src/main/scala/org/http4s/googleapis/runtime/auth/OAuth2Credentials.scala
@@ -69,7 +69,7 @@ object Oauth2Credentials {
           )
           scopes = scopesOverride.getOrElse(DEFAULT_SCOPES)
           credentials <- Oauth2Credentials(
-            pid,
+            Some(pid),
             GoogleOAuth2RefreshToken[F](client)
               .getAccessToken(client_id, client_secret, refresh_token, scopes),
           )
@@ -90,7 +90,7 @@ object Oauth2Credentials {
         )
     }
 
-  private[auth] def apply[F[_]](pid: String, refresh: F[AccessToken])(implicit
+  private[auth] def apply[F[_]](pid: Option[String], refresh: F[AccessToken])(implicit
       F: Temporal[F],
   ): F[GoogleCredentials[F]] =
     for {


### PR DESCRIPTION
In Java implementation, some credentials implement QuotaProjectIdProvider, but the others do not.

Spec says clients __SHOULD__ add quota-project-id to request headers, but it is not mandatory requrements.

https://github.com/googleapis/google-auth-library-java/blob/ab872812d0f6e9ad7598ba4c4c503d5bff6c2a2b/oauth2_http/java/com/google/auth/oauth2/QuotaProjectIdProvider.java